### PR TITLE
[127] FINDING-10642: Update Cache-Headers Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ With the example above, the `Cache-Control` header is set as follows when a user
 - `/user/route`
     - `Cache-Control: private, no-cache, no-store, must-revalidate`
     - `Surrogate-Control: maxAge=0`
+    - `Last-Modified: (NOW)`
 - `/**` (any other route not listed)
     - `Cache-Control: no-cache, no-store, must-revalidate`
     - `Surrogate-Control: maxAge=60`
@@ -101,9 +102,9 @@ The following are acceptable keys to use if an object is passed in
 
 | key | type | description | default |
 | --- | ---- | ----------- | ------- |
-| `lastModified` | string | set `Last-Modified Header` | current date |
+| `lastModified` | string | set `Last-Modified Header` | |
 | `maxAge` | string, number | number or string representing a number for `Surrogate-Control: max-age` (forced to `0` if `setPrivate=true`) | `TEN_MINUTES` (600 seconds) |
-| `setPrivate` | boolean | should add `Cache-Control: private` (if set to `true` forces `Surrogate-Control: maxAge=0`) | false |
+| `setPrivate` | boolean | should add `Cache-Control: private` (if set to `true` forces `Surrogate-Control: maxAge=0` and `Last-Modified: (NOW)`) | false |
 | `staleError` | string, number | number or string representing a number for `Cache-Control: stale-if-error` |  |
 | `staleRevalidate` | string, number | number or string representing a number for `Cache-Control: stale-while-revalidate` |  |
 
@@ -139,9 +140,9 @@ If no options are passed in, the default value set is
 ```
 | key | type | description | default |
 | --- | ---- | ----------- | ------- |
-| `lastModified` | string | set `Last-Modified Header` | current date |
+| `lastModified` | string | set `Last-Modified Header` | |
 | `maxAge` | string, number | number or string representing a number for `Surrogate-Control: max-age` (forced to `0` if `setPrivate=true`) | `TEN_MINUTES` (600 seconds) |
-| `setPrivate` | boolean | should add `Cache-Control: private` (if set to `true` forces `Surrogate-Control: maxAge=0`) | false |
+| `setPrivate` | boolean | should add `Cache-Control: private` (if set to `true` forces `Surrogate-Control: maxAge=0` and `Last-Modified: (NOW)`) | false |
 | `staleError` | string, number | number or string representing a number for `Cache-Control: stale-if-error` |  |
 | `staleRevalidate` | string, number | number or string representing a number for `Cache-Control: stale-while-revalidate` |  |
 
@@ -166,9 +167,10 @@ Headers Output:
 Options for pages that are intended for all users and should be cached in both the browser and the server. 
 ```js
 {
-    maxAge: 'ONE_WEEK',             // cache on server
-    staleError: 'ONE_MONTH',        // cache on browser if server returns error
-    staleRevalidate: 'TEN_MINUTES'  // cache on browser for 10 min
+    maxAge: 'ONE_WEEK',                             // cache on server
+    staleError: 'ONE_MONTH',                        // cache on browser if server returns error
+    staleRevalidate: 'TEN_MINUTES',                 // cache on browser for 10 min
+    lastModified: 'Fri, 23 Jun 2017 14:35:44 GMT'   // some deployTime from a versionReport
 }
 ```
 Headers Output: 
@@ -177,7 +179,7 @@ Headers Output:
 'Surrogate-Control': 'maxAge=604800'
 'Pragma': 'no-cache'
 'Expires': 0
-'Last-Modified': (NOW)
+'Last-Modified': 'Fri, 23 Jun 2017 14:35:44 GMT'
 ```
 
 ## Additional notes on header use / specification 

--- a/__tests__/cacheControl_spec.js
+++ b/__tests__/cacheControl_spec.js
@@ -32,8 +32,7 @@ describe('cache control', function () {
         now = formatDate(new Date('2001-01-01'));
         staticHeaders = {
             Expires: 0,
-            Pragma: 'no-cache',
-            'Last-Modified': now
+            Pragma: 'no-cache'
         };
         lastModifiedHeader = {
             [KEY_LAST_MODIFIED]: now
@@ -53,7 +52,8 @@ describe('cache control', function () {
         const actual = generateAllCacheHeaders(lastModifiedHeader);
         const expect = {
             [CACHE_CONTROL_STR]: NO_CACHE_NO_STORE,
-            [SURROGATE_CONTROL_STR]: 'max-age=600'
+            [SURROGATE_CONTROL_STR]: 'max-age=600',
+            'Last-Modified': now
         };
         headerAssertions(actual, expect);
     });
@@ -64,7 +64,8 @@ describe('cache control', function () {
         }));
         const expect = {
             [CACHE_CONTROL_STR]: `${NO_CACHE_NO_STORE}, stale-while-revalidate=200, stale-if-error=300`,
-            [SURROGATE_CONTROL_STR]: 'max-age=600'
+            [SURROGATE_CONTROL_STR]: 'max-age=600',
+            'Last-Modified': now
         };
         headerAssertions(actual, expect);
     });
@@ -75,7 +76,8 @@ describe('cache control', function () {
         }));
         const expect = {
             [CACHE_CONTROL_STR]: `${NO_CACHE_NO_STORE}, stale-while-revalidate=60, stale-if-error=10`,
-            [SURROGATE_CONTROL_STR]: 'max-age=600'
+            [SURROGATE_CONTROL_STR]: 'max-age=600',
+            'Last-Modified': now
         };
         headerAssertions(actual, expect);
     });
@@ -86,7 +88,8 @@ describe('cache control', function () {
         }));
         const expect = {
             [CACHE_CONTROL_STR]: `private, ${NO_CACHE_NO_STORE}`,
-            [SURROGATE_CONTROL_STR]: 'max-age=0'
+            [SURROGATE_CONTROL_STR]: 'max-age=0',
+            'Last-Modified': now
         };
         headerAssertions(actual, expect);
     });
@@ -97,7 +100,8 @@ describe('cache control', function () {
         }));
         const expect = {
             [CACHE_CONTROL_STR]: `${NO_CACHE_NO_STORE}, stale-while-revalidate=60, stale-if-error=604800`,
-            [SURROGATE_CONTROL_STR]: 'max-age=600'
+            [SURROGATE_CONTROL_STR]: 'max-age=600',
+            'Last-Modified': now
         };
         headerAssertions(actual, expect);
     });
@@ -108,7 +112,8 @@ describe('cache control', function () {
         }));
         const expect = {
             [CACHE_CONTROL_STR]: `${NO_CACHE_NO_STORE}, stale-while-revalidate=0, stale-if-error=0`,
-            [SURROGATE_CONTROL_STR]: 'max-age=600'
+            [SURROGATE_CONTROL_STR]: 'max-age=600',
+            'Last-Modified': now
         };
         headerAssertions(actual, expect);
     });
@@ -119,7 +124,8 @@ describe('cache control', function () {
         }));
         const expect = {
             [CACHE_CONTROL_STR]: NO_CACHE_NO_STORE,
-            [SURROGATE_CONTROL_STR]: 'max-age=600'
+            [SURROGATE_CONTROL_STR]: 'max-age=600',
+            'Last-Modified': now
         };
         headerAssertions(actual, expect);
     });
@@ -138,7 +144,8 @@ describe('cache control', function () {
                 staticHeaders,
                 {
                     [CACHE_CONTROL_STR]: NO_CACHE_NO_STORE,
-                    [SURROGATE_CONTROL_STR]: `max-age=${time}`
+                    [SURROGATE_CONTROL_STR]: `max-age=${time}`,
+                    'Last-Modified': now
                 }
             );
         }

--- a/__tests__/index_spec.js
+++ b/__tests__/index_spec.js
@@ -426,46 +426,4 @@ describe('cache control index', function () {
         });
 
     });
-
-    describe('setAdditionalHeaders', function () {
-        let app;
-        it("should set headers passed in", (done) => {
-            const additionalHeaders = [
-                {
-                    'custom-header': 'yes',
-                    'another-header': 100
-                },
-                {
-                    name: 'set-by-name',
-                    value: 'set by value'
-                }
-            ];
-
-            app = express();
-            app.use(api.setAdditionalHeaders(additionalHeaders));
-            createMockRoutes(app);
-            server = createServer(app);
-            request(server).get('/')
-                .end((err, res) => {
-                    const expectedHeaders = [
-                        {name: 'custom-header', value: 'yes'},
-                        {name: 'another-header', value: '100'},
-                        {name: 'set-by-name', value: 'set by value'}
-                    ];
-                    testHeaders(res, expectedHeaders);
-                    done();
-                });
-        });
-        it('should use the default empty array when nothing is passed in', (done) => {
-            app = express();
-            app.use(api.setAdditionalHeaders());
-            server = createServer(app);
-            request(server).get('/')
-                .end((err, res) => {
-                    const expectedHeaders = [];
-                    testHeaders(res, expectedHeaders);
-                    done();
-                });
-        });
-    });
 });

--- a/src/cacheControl.js
+++ b/src/cacheControl.js
@@ -135,14 +135,14 @@ function generateExpiresHeader() {
 }
 
 function generateLastModifiedHeader(options) {
-    let {lastModified = false} = options;
+    let { lastModified = false } = options;
+    const { setPrivate = false } = options;
 
-    if (!lastModified) {
+    if (setPrivate) {
         lastModified = formatDate();
     }
-    return {
-        'Last-Modified': lastModified
-    };
+
+    return lastModified ? { 'Last-Modified': lastModified } : {};
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -25,30 +25,9 @@ export * from './timeValues';
  * {{@link http://expressjs.com/en/api.html#res.set}}
  * @param {object} res The current response object
  * @param {object} headerData
- * @param {string} [headerData.name] The response header to use
- * @param {string} [headerData.value] The corresponding response header value
  */
 function setHeader(res, headerData) {
-    if (headerData.name && headerData.value) {
-        res.set(headerData.name, headerData.value);
-    } else {
-        res.set(headerData);
-    }
-}
-
-/**
- * @param {object<array>} headers
- * @param {string} headers[].name The header name
- * @param {string} headers[].value The header value
- * @returns {function(*, *=, *)}
- */
-export function setAdditionalHeaders(headers = []) {
-    return (req, res, next) => {
-        if (Array.isArray(headers) && headers.length) {
-            headers.map(headerData => setHeader(res, headerData));
-        }
-        next();
-    };
+    res.set(headerData);
 }
 
 /**


### PR DESCRIPTION
- Removed `setAdditionalHeaders()` since its not being used and instead `overrideCacheHeaders()` should be used.
- Removed default `"Last-Modified"` value so that `overrideCacheHeaders()` doesn't always overwrite the value. 
- Added check to force `"Last-Modified"` to be set to the current time when `setPrivate=true`
- Updated Tests/README

This PR Relates to: 
`1stdibs.com` PR: [[127] FINDING-10642: Update Cache-Headers Package](https://github.com/1stdibs/1stdibs.com/pull/9701)
Prev `cache-headers` PR: [Updates](https://github.com/1stdibs/cache-headers/pull/9)